### PR TITLE
cysignals requires cython at runtime

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - issue-159.patch  # [aarch64]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:
@@ -39,6 +39,7 @@ requirements:
   run:
     - python
     - pari
+    - {{ pin_compatible('cython') }}
 
 test:
   imports:


### PR DESCRIPTION
cysignals is built against Cython, so a compatible version of it is required at runtime.

This requirement is made explicit in the setup.py btw where it says that `install_requires` cython.